### PR TITLE
Updated launch settings to fix testing the extension from VSCODE

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,11 +24,12 @@
       "request": "launch",
       "runtimeExecutable": "${execPath}",
       "args": [
+        "./tests/workspace/",
         "--extensionDevelopmentPath=${workspaceFolder}",
-        "--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
+        "--extensionTestsPath=${workspaceFolder}/out/tests/suite/index"
       ],
       "outFiles": [
-        "${workspaceFolder}/out/test/**/*.js"
+        "${workspaceFolder}/out/tests/**/*.js"
       ],
       "preLaunchTask": "npm: watch"
     }


### PR DESCRIPTION
While developing this extension it would be great to debug our tests from within VSCODE instead of using the `npm run test` script. This would allow us to actually utilize the debugger within VSCODE to test our unit tests, and is faster than the npm script option allowing us to iterate quicker.

This PR fixes a couple issues found within the `launch.json` which prevented the startup of the VSCODE Extension Development Host environment. With these changes, VSCODE launches the Development Host environment, opens the test workspace and runs our tests then exists. All the tests will output to the `DEBUG CONSOLE` window in VSCODE.